### PR TITLE
fix conext/elapsed parameter in sample-renderer system

### DIFF
--- a/src/systems/renderer/sample-renderer-system.js
+++ b/src/systems/renderer/sample-renderer-system.js
@@ -1,6 +1,6 @@
 "use strict";
 
 module.exports = function(ecs, game) { // eslint-disable-line no-unused-vars
-  ecs.addEach(function(entity, context) { // eslint-disable-line no-unused-vars
+  ecs.addEach(function(entity, elapsed) { // eslint-disable-line no-unused-vars
   }, "playerController2d");
 };


### PR DESCRIPTION
parameter is named 'context', should be 'elapsed'.
context comes from  game.context now.
